### PR TITLE
Add lang attribute to html-tag

### DIFF
--- a/skbl/templates/layout.html
+++ b/skbl/templates/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="{{ g.language }}">
   <head>
     {% block head %}
     <title>{% block title %}{% endblock %}</title>


### PR DESCRIPTION
Recommended attribute to indicate the language of the page:
https://dequeuniversity.com/rules/axe/4.7/html-has-lang
